### PR TITLE
Dev gamepad support branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ endif (UNIX)
 
 add_executable(gb ${SOURCE_FILES})
 add_executable(rom_info tools/rom_info/rom_info.c src/rom.c)
+add_executable(joypad_mapping tools/joypad_mapping/joypad_mapping.c)
 
 if (WIN32 OR MSYS OR MINGW )
     target_link_libraries(gb -lmingw32 -lSDL2main -lSDL2  opengl32  glu32 m dinput8 dxguid dxerr8 user32 gdi32 winmm imm32 ole32 oleaut32 shell32 version uuid)
@@ -53,4 +54,5 @@ endif (USE_CONSOLE_DEBUGGER)
 if (UNIX)  
    target_link_libraries(gb ${SDL2_LIBRARY} ${OPENGL_LIBRARIES})
    target_link_libraries(rom_info ${SDL2_LIBRARY})
+   target_link_libraries(joypad_mapping ${SDL2_LIBRARY})
 endif (UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif (UNIX)
 
 add_executable(gb ${SOURCE_FILES})
 add_executable(rom_info tools/rom_info/rom_info.c src/rom.c)
-add_executable(joypad_mapping tools/joypad_mapping/joypad_mapping.c)
+add_executable(joypad_mapping tools/joypad_mapping/joypad_mapping.c src/ae_config.c)
 
 if (WIN32 OR MSYS OR MINGW )
     target_link_libraries(gb -lmingw32 -lSDL2main -lSDL2  opengl32  glu32 m dinput8 dxguid dxerr8 user32 gdi32 winmm imm32 ole32 oleaut32 shell32 version uuid)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ endif (UNIX)
 
 add_executable(gb ${SOURCE_FILES})
 add_executable(rom_info tools/rom_info/rom_info.c src/rom.c)
-add_executable(joypad_mapping tools/joypad_mapping/joypad_mapping.c src/ae_config.c)
+add_executable(joypad_mapping tools/joypad_mapping/joypad_mapping.c
+	src/ae_config.c src/joystick_config.c src/utils.c)
 
 if (WIN32 OR MSYS OR MINGW )
     target_link_libraries(gb -lmingw32 -lSDL2main -lSDL2  opengl32  glu32 m dinput8 dxguid dxerr8 user32 gdi32 winmm imm32 ole32 oleaut32 shell32 version uuid)

--- a/include/GB.h
+++ b/include/GB.h
@@ -1,6 +1,8 @@
 #ifndef __GB__
 #define __GB__
 
+#include <linux/limits.h>
+
 #include "stdlib.h"
 #include <stdio.h>
 #include <string.h>
@@ -14,6 +16,7 @@
 #include "timer.h"
 #include "memory.h"
 #include "log.h"
+#include "joystick_config.h"
 
 //main struct
 
@@ -30,6 +33,8 @@ struct						s_gb
 	struct s_memory			gb_mem;
 	struct s_joypad			gb_pad;
 	struct s_cpu			gb_cpu;
+	struct joystick_config joystick_config;
+	char config_dir_path[PATH_MAX];
 
 	unsigned char			stopdbg;
 };

--- a/include/ae_config.h
+++ b/include/ae_config.h
@@ -1,0 +1,14 @@
+#ifndef AE_CONFIG_H_
+#define AE_CONFIG_H_
+
+struct ae_config {
+	char *argz;
+	size_t len;
+};
+
+int ae_config_read(struct ae_config *conf, const char *path);
+int ae_config_read_from_string(struct ae_config *conf, const char *string);
+const char *ae_config_get(const struct ae_config *conf, const char *key);
+void ae_config_cleanup(struct ae_config *conf);
+
+#endif /* AE_CONFIG_H_ */

--- a/include/joystick_config.h
+++ b/include/joystick_config.h
@@ -1,0 +1,111 @@
+#ifndef INCLUDE_JOYSTICK_CONFIG_H_
+#define INCLUDE_JOYSTICK_CONFIG_H_
+#include <stdbool.h>
+#include <inttypes.h>
+
+#include <SDL2/SDL.h>
+
+#define MAX_JOYSTICKS 10
+#define MAPPINGS_SIZE 8
+#define GUID_SIZE 33
+
+struct joystick {
+	SDL_Joystick *joystick;
+	char *name;
+	char guid[GUID_SIZE];
+	int index;
+	SDL_JoystickID id;
+	struct {
+		int axes;
+		int balls;
+		int hats;
+		int buttons;
+	} num;
+};
+
+enum control_type {
+	CONTROL_TYPE_FIRST,
+
+	CONTROL_TYPE_BALL = CONTROL_TYPE_FIRST,
+	CONTROL_TYPE_AXIS,
+	CONTROL_TYPE_HAT,
+	CONTROL_TYPE_BUTTON,
+
+	CONTROL_TYPE_LAST = CONTROL_TYPE_BUTTON,
+	CONTROL_TYPE_INVALID
+};
+
+/* values must stay 0 -> 3 for right -> down and 0 + 4 -> 3 + 4 for others */
+enum gb_button {
+	GB_BUTTON_FIRST = 0,
+
+	GB_BUTTON_RIGHT = GB_BUTTON_FIRST,
+	GB_BUTTON_LEFT,
+	GB_BUTTON_UP,
+	GB_BUTTON_DOWN,
+	GB_BUTTON_A,
+	GB_BUTTON_B,
+	GB_BUTTON_SELECT,
+	GB_BUTTON_START,
+
+	GB_BUTTON_LAST = GB_BUTTON_START,
+	GB_BUTTON_INVALID
+};
+
+struct control {
+	enum control_type type;
+	union {
+		struct {
+			uint8_t index;
+			int16_t value;
+		} axis;
+		struct {
+			uint8_t index;
+			uint8_t value;
+		} hat;
+		struct {
+			uint8_t index;
+		} button;
+	};
+};
+
+struct mapping {
+	enum gb_button button;
+	struct control control;
+};
+
+struct button_states {
+	union {
+		struct {
+			bool up;
+			bool right;
+			bool down;
+			bool left;
+			bool a;
+			bool b;
+			bool start;
+			bool select;
+		};
+		bool array[MAPPINGS_SIZE];
+	};
+};
+
+struct joystick_config {
+	bool initialized;
+	struct joystick joystick;
+	struct button_states buttons;
+	struct mapping mappings[MAPPINGS_SIZE];
+};
+
+void close_joystick_config(struct joystick_config *jc);
+void cleanup_joystick_config(struct joystick_config *joystick_config);
+void reset_joystick_config(struct joystick_config *joystick_config);
+int init_joystick_config(struct joystick_config *joystick_config,
+		int index, const char *mappings_dir);
+/* __attribute__((printf(2, 3))) */
+int load_mapping(struct mapping mappings[MAPPINGS_SIZE], const char *fmt, ...);
+char *canonicalize_joystick_name(char *name);
+const char *control_type_to_str(enum control_type type);
+const char *gb_button_to_str(enum gb_button button);
+
+#endif /* INCLUDE_JOYSTICK_CONFIG_H_ */

--- a/include/utils.h
+++ b/include/utils.h
@@ -11,6 +11,7 @@
 #define CLEAR_BIT(f, b) ((f) &= ~(1 << (b)))
 
 #define cleanup(f) __attribute((cleanup(f)))
+#define have_same_sign(n1, n2) (((n1) * (n2)) >= 0)
 
 static inline bool str_matches(const char *s1, const char *s2)
 {

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,13 +1,16 @@
 #ifndef _UTILS_H
 #define _UTILS_H
-
+#include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 
 #define BIT0(v) ((v) & 1)
 #define BIT(i, v) BIT0((v) >> (i))
 
 #define SET_BIT(f, b) ((f) |= (1 << (b)))
 #define CLEAR_BIT(f, b) ((f) &= ~(1 << (b)))
+
+#define cleanup(f) __attribute((cleanup(f)))
 
 static inline bool str_matches(const char *s1, const char *s2)
 {
@@ -29,5 +32,8 @@ static inline char *str_diff_chr(const char *s1, const char *s2)
 
 	return (char *)s1;
 }
+
+void cleanup_string(char **str);
+void cleanup_file(FILE **pfile);
 
 #endif /* _UTILS_H */

--- a/src/ae_config.c
+++ b/src/ae_config.c
@@ -1,0 +1,75 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <argz.h>
+#include <envz.h>
+
+#include "ae_config.h"
+
+static void file_cleanup(FILE **f)
+{
+	if (f == NULL || *f == NULL)
+		return;
+
+	fclose(*f);
+	*f = NULL;
+}
+
+static void string_cleanup(char **s)
+{
+	if (s == NULL || *s == NULL)
+		return;
+
+	free(*s);
+	*s = NULL;
+}
+
+int ae_config_read(struct ae_config *conf, const char *path)
+{
+	int ret;
+	char __attribute__((cleanup(string_cleanup)))*string = NULL;
+	FILE __attribute__((cleanup(file_cleanup)))*f = NULL;
+	long size;
+	size_t sret;
+
+	f = fopen(path, "rbe");
+	if (f == NULL)
+		return -errno;
+
+	/* compute the size of the file */
+	ret = fseek(f, 0, SEEK_END);
+	if (ret == -1)
+		return -errno;
+	size = ftell(f);
+	if (ret == -1)
+		return -errno;
+	ret = fseek(f, 0, SEEK_SET);
+	if (ret == -1)
+		return -errno;
+
+	/* read all */
+	string = calloc(size, 1);
+	if (string == NULL)
+		return -errno;
+
+	sret = fread(string, 1, size, f);
+	if (sret < (size_t)size)
+		return feof(f) ? -EIO : ret;
+
+	return ae_config_read_from_string(conf, string);
+}
+
+int ae_config_read_from_string(struct ae_config *conf, const char *string)
+{
+	return -argz_create_sep(string, '\n', &conf->argz, &conf->len);
+}
+
+const char *ae_config_get(const struct ae_config *conf, const char *key)
+{
+	return envz_get(conf->argz, conf->len, key);
+}
+
+void ae_config_cleanup(struct ae_config *conf)
+{
+	free(conf->argz);
+	memset(conf, 0, sizeof(*conf));
+}

--- a/src/gpu.c
+++ b/src/gpu.c
@@ -9,7 +9,7 @@ void initDisplay(struct s_gb *s_gb)
 #ifdef EMGB_CONSOLE_DEBUGGER
   SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
 #endif /* EMGB_CONSOLE_DEBUGGER */
-  SDL_Init(SDL_INIT_VIDEO);
+  SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK);
 	
   s_gb->gb_gpu.window = SDL_CreateWindow("GB",
 					 300, 300, GB_W, GB_H, 0);

--- a/src/init.c
+++ b/src/init.c
@@ -2,9 +2,9 @@
 
 
 
-struct s_gb	*initGb(char *fileName)
+struct s_gb *initGb(char *fileName)
 {
-	struct s_gb		*s_gb = NULL;
+	struct s_gb *s_gb = NULL;
 
 	s_gb = malloc(sizeof(*s_gb));
 	if (s_gb == NULL)
@@ -16,7 +16,10 @@ struct s_gb	*initGb(char *fileName)
 	initGpu(s_gb);
 	initTimer(s_gb);
 	initCpu(s_gb);
-	return (s_gb);
+	reset_joystick_config(&s_gb->joystick_config);
+	snprintf(s_gb->config_dir_path, PATH_MAX, "%s/.emgb/", getenv("HOME"));
+
+	return s_gb;
 }
 
 void	initRegister(struct s_gb *s_gb)

--- a/src/joypad.c
+++ b/src/joypad.c
@@ -85,6 +85,7 @@ void handleEvent(struct s_gb * gb_s)
 		case SDL_QUIT: {
 			printf("see u.\n");
 			gb_s->running = 0;
+			break;
 		}
 		case SDL_KEYDOWN:
 			keyDown(gb_s);

--- a/src/joypad.c
+++ b/src/joypad.c
@@ -110,10 +110,24 @@ void handleEvent(struct s_gb *gb_s)
 		ret = init_joystick_config(joystick_config,
 				event->jdevice.which, gb_s->config_dir_path);
 		if (ret < 0) {
-			printf("No mapping found for %s\n", joystick_name);
+			printf("No mapping found for %s, use joypad_mapping to "
+					"create one\n", joystick_name);
 			cleanup_joystick_config(joystick_config);
 		}
 		break;
+
+	case SDL_JOYDEVICEREMOVED:
+		printf("Joystick SDL_JoystickID = %"PRIi32" removed.%*s\n",
+				event->jdevice.which, 25, "");
+		if (!joystick_config->initialized)
+			break;
+		if (joystick_config->joystick.id != event->jdevice.which)
+			break;
+		printf("Waiting for joystick detection\n");
+
+		cleanup_joystick_config(joystick_config);
+		break;
+
 	case SDL_KEYDOWN:
 		keyDown(gb_s);
 		break;

--- a/src/joypad.c
+++ b/src/joypad.c
@@ -3,6 +3,22 @@
 
 #define MAPPINGS_DIR "~/.emgb/"
 
+#define BUTTON_RIGHT_FLAG (1 << 0)
+#define BUTTON_LEFT_FLAG (1 << 1)
+#define BUTTON_UP_FLAG (1 << 2)
+#define BUTTON_DOWN_FLAG (1 << 3)
+
+/* TODO check A and B aren't swapped with a real game boy */
+#define BUTTON_A_FLAG (1 << 0)
+#define BUTTON_B_FLAG (1 << 1)
+#define BUTTON_SELECT_FLAG (1 << 2)
+#define BUTTON_START_FLAG (1 << 3)
+
+#define BUTTON_KEY_OR_DIR_MASK 0x04
+#define BUTTON_IS_KEY(b) (!!((b) & BUTTON_KEY_OR_DIR_MASK))
+#define BUTTON_TO_KEY(b) (1 << ((b) & ~BUTTON_KEY_OR_DIR_MASK))
+#define BUTTON_TO_DIR(b) (1 << (b))
+
 void keyDown(struct s_gb * gb_s)
 {
 	gb_s->gb_cpu.stopCpu = 0;
@@ -14,35 +30,35 @@ void keyDown(struct s_gb * gb_s)
 		break;
 	case SDLK_w:
 		gb_s->gb_interrupts.interFlag |= INT_JOYPAD;
-		gb_s->gb_pad.button_key &= ~(1 << 3);
+		gb_s->gb_pad.button_key &= ~BUTTON_DOWN_FLAG;
 		break;
 	case SDLK_x:
 		gb_s->gb_interrupts.interFlag |= INT_JOYPAD;
-		gb_s->gb_pad.button_key &= ~(1 << 2);
+		gb_s->gb_pad.button_key &= ~BUTTON_UP_FLAG;
 		break;
 	case SDLK_c:
 		gb_s->gb_interrupts.interFlag |= INT_JOYPAD;
-		gb_s->gb_pad.button_key &= ~(1 << 1);
+		gb_s->gb_pad.button_key &= ~BUTTON_LEFT_FLAG;
 		break;
 	case SDLK_v:
 		gb_s->gb_interrupts.interFlag |= INT_JOYPAD;
-		gb_s->gb_pad.button_key &= ~(1 << 0);
+		gb_s->gb_pad.button_key &= ~BUTTON_RIGHT_FLAG;
 		break;
 	case SDLK_DOWN:
 		gb_s->gb_interrupts.interFlag |= INT_JOYPAD;
-		gb_s->gb_pad.button_dir &= ~(1 << 3);
+		gb_s->gb_pad.button_dir &= ~BUTTON_START_FLAG;
 		break;
 	case SDLK_UP:
 		gb_s->gb_interrupts.interFlag |= INT_JOYPAD;
-		gb_s->gb_pad.button_dir &= ~(1 << 2);
+		gb_s->gb_pad.button_dir &= ~BUTTON_SELECT_FLAG;
 		break;
 	case SDLK_LEFT:
 		gb_s->gb_interrupts.interFlag |= INT_JOYPAD;
-		gb_s->gb_pad.button_dir &= ~(1 << 1);
+		gb_s->gb_pad.button_dir &= ~BUTTON_B_FLAG;
 		break;
 	case SDLK_RIGHT:
 		gb_s->gb_interrupts.interFlag |= INT_JOYPAD;
-		gb_s->gb_pad.button_dir &= ~(1 << 0);
+		gb_s->gb_pad.button_dir &= ~BUTTON_A_FLAG;
 		break;
 	}
 	return;
@@ -53,28 +69,28 @@ void keyUp(struct s_gb * gb_s)
 	switch (gb_s->gb_gpu.event.key.keysym.sym)
 	{
 	case SDLK_w:
-		gb_s->gb_pad.button_key |= (1 << 3);
+		gb_s->gb_pad.button_key |= BUTTON_DOWN_FLAG;
 		break;
 	case SDLK_x:
-		gb_s->gb_pad.button_key |= (1 << 2);
+		gb_s->gb_pad.button_key |= BUTTON_UP_FLAG;
 		break;
 	case SDLK_c:
-		gb_s->gb_pad.button_key |= (1 << 1);
+		gb_s->gb_pad.button_key |= BUTTON_LEFT_FLAG;
 		break;
 	case SDLK_v:
-		gb_s->gb_pad.button_key |= (1 << 0);
+		gb_s->gb_pad.button_key |= BUTTON_RIGHT_FLAG;
 		break;
 	case SDLK_DOWN:
-		gb_s->gb_pad.button_dir |= (1 << 3);
+		gb_s->gb_pad.button_dir |= BUTTON_START_FLAG;
 		break;
 	case SDLK_UP:
-		gb_s->gb_pad.button_dir |= (1 << 2);
+		gb_s->gb_pad.button_dir |= BUTTON_SELECT_FLAG;
 		break;
 	case SDLK_LEFT:
-		gb_s->gb_pad.button_dir |= (1 << 1);
+		gb_s->gb_pad.button_dir |= BUTTON_B_FLAG;
 		break;
 	case SDLK_RIGHT:
-		gb_s->gb_pad.button_dir |= (1 << 0);
+		gb_s->gb_pad.button_dir |= BUTTON_A_FLAG;
 		break;
 	}
 }
@@ -119,9 +135,63 @@ static void joy_device_removed(struct s_gb *gb, const union SDL_Event *event)
 	cleanup_joystick_config(joystick_config);
 }
 
+/*
+ * TODO factor the joy_button_down and joy_button_up, this should be done when
+ * button flags have been properly broken up using bit fields
+ */
+static void joy_button_down(struct s_gb *gb, const union SDL_Event *event)
+{
+	struct joystick_config *joystick_config;
+	enum gb_button button;
+	struct control *control;
+
+	joystick_config = &gb->joystick_config;
+	if (!joystick_config->initialized)
+		return;
+
+	for (button = GB_BUTTON_FIRST; button <= GB_BUTTON_LAST;
+			button++) {
+		control = &joystick_config->mappings[button].control;
+		if (control->type != CONTROL_TYPE_BUTTON)
+			continue;
+		if (control->button.index == event->jbutton.button) {
+			gb->gb_interrupts.interFlag |= INT_JOYPAD;
+			gb->gb_cpu.stopCpu = 0;
+			if (BUTTON_IS_KEY(button))
+				gb->gb_pad.button_key &= ~BUTTON_TO_KEY(button);
+			else
+				gb->gb_pad.button_dir &= ~BUTTON_TO_DIR(button);
+		}
+	}
+}
+
+static void joy_button_up(struct s_gb *gb, const union SDL_Event *event)
+{
+	struct joystick_config *joystick_config;
+	enum gb_button button;
+	struct control *control;
+
+	joystick_config = &gb->joystick_config;
+	if (!joystick_config->initialized)
+		return;
+
+	for (button = GB_BUTTON_FIRST; button <= GB_BUTTON_LAST;
+			button++) {
+		control = &joystick_config->mappings[button].control;
+		if (control->type != CONTROL_TYPE_BUTTON)
+			continue;
+		if (control->button.index == event->jbutton.button) {
+			if (BUTTON_IS_KEY(button))
+				gb->gb_pad.button_key |= BUTTON_TO_KEY(button);
+			else
+				gb->gb_pad.button_dir |= BUTTON_TO_DIR(button);
+		}
+	}
+}
+
 void handleEvent(struct s_gb *gb_s)
 {
-	SDL_Event *event;
+	union SDL_Event *event;
 
 	event = &(gb_s->gb_gpu.event);
 	if (SDL_PollEvent(event) == 0)
@@ -140,6 +210,14 @@ void handleEvent(struct s_gb *gb_s)
 
 	case SDL_JOYDEVICEREMOVED:
 		joy_device_removed(gb_s, event);
+		break;
+
+	case SDL_JOYBUTTONDOWN:
+		joy_button_down(gb_s, event);
+		break;
+
+	case SDL_JOYBUTTONUP:
+		joy_button_up(gb_s, event);
 		break;
 
 	case SDL_KEYDOWN:

--- a/src/joystick_config.c
+++ b/src/joystick_config.c
@@ -1,0 +1,231 @@
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "joystick_config.h"
+#include "utils.h"
+#include "ae_config.h"
+
+static void reset_mappings(struct mapping mappings[MAPPINGS_SIZE])
+{
+	int i;
+
+	memset(mappings, 0, sizeof(*mappings) * MAPPINGS_SIZE);
+
+	for (i = 0; i <= GB_BUTTON_LAST; i++)
+		mappings[i].button = GB_BUTTON_INVALID;
+}
+
+static enum control_type control_type_from_string_prefix(const char *str)
+{
+	enum control_type type;
+	const char *type_str;
+
+	for (type = CONTROL_TYPE_FIRST; type <= CONTROL_TYPE_LAST; type++) {
+		type_str = control_type_to_str(type);
+		if (strncmp(str, type_str, strlen(type_str)) == 0)
+			break;
+	}
+
+	return type;
+}
+
+void close_joystick_config(struct joystick_config *jc)
+{
+	if (jc == NULL || jc->joystick.joystick == NULL)
+		return;
+
+	SDL_JoystickClose(jc->joystick.joystick);
+}
+
+void cleanup_joystick_config(struct joystick_config *joystick_config)
+{
+	close_joystick_config(joystick_config);
+	reset_joystick_config(joystick_config);
+}
+
+void reset_joystick_config(struct joystick_config *joystick_config)
+{
+	memset(joystick_config, 0, sizeof(*joystick_config));
+	reset_mappings(joystick_config->mappings);
+}
+
+int init_joystick_config(struct joystick_config *joystick_config,
+		int index, const char *mappings_dir)
+{
+	int ret;
+	struct joystick *joystick;
+	char cleanup(cleanup_string) *canon_name = NULL;
+
+	reset_joystick_config(joystick_config);
+
+	joystick_config->initialized = true;
+	joystick = &joystick_config->joystick;
+	joystick->index = index;
+	joystick->joystick = SDL_JoystickOpen(index);
+	if (joystick->joystick == NULL) {
+		fprintf(stderr, "SDL_JoystickOpen(%d)\n", index);
+		return -EINVAL;
+	}
+	joystick->name = SDL_JoystickNameForIndex(index);
+	joystick->num.axes = SDL_JoystickNumAxes(joystick->joystick);
+	joystick->num.balls = SDL_JoystickNumBalls(joystick->joystick);
+	joystick->num.hats = SDL_JoystickNumHats(joystick->joystick);
+	joystick->num.buttons = SDL_JoystickNumButtons(joystick->joystick);
+	joystick->id = SDL_JoystickInstanceID(joystick->joystick);
+	SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(joystick->joystick),
+			joystick->guid, GUID_SIZE);
+
+	if (mappings_dir == NULL)
+		return 0;
+
+	canon_name = strdup(joystick->name);
+	if (canon_name == NULL)
+		return -errno;
+	canonicalize_joystick_name(canon_name);
+	printf("looking for %s/%s.mapping\n", mappings_dir, canon_name);
+	ret = load_mapping(joystick_config->mappings, "%s/%s.mapping",
+			mappings_dir, canon_name);
+	if (ret != 0)
+		return ret;
+
+	printf("loaded mapping successfully\n");
+
+	return 0;
+}
+
+/* __attribute__((printf(2, 3))) */ int load_mapping(
+		struct mapping mappings[MAPPINGS_SIZE], const char *fmt, ...)
+{
+	int ret;
+	va_list args;
+	char cleanup(cleanup_string)*path = NULL;
+	FILE cleanup(cleanup_file)*f = NULL;
+	struct ae_config cleanup(ae_config_cleanup)config = {
+			.argz = NULL,
+			.len = 0,
+	};
+	enum gb_button button;
+	const char *button_config;
+	enum control_type type;
+	struct mapping *mapping;
+
+	va_start(args, fmt);
+	ret = vasprintf(&path, fmt, args);
+	va_end(args);
+	if (ret < 0) {
+		path = NULL;
+		fprintf(stderr, "vasprintf failed\n");
+		return -ENOMEM;
+	}
+	ret = ae_config_read(&config, path);
+	if (ret < 0) {
+		fprintf(stderr, "ae_config_read: %s\n", strerror(-ret));
+		return ret;
+	}
+
+	for (button = GB_BUTTON_FIRST; button <= GB_BUTTON_LAST; button++) {
+		button_config = ae_config_get(&config,
+				gb_button_to_str(button));
+		mapping = mappings + button;
+		mapping->button = button;
+		type = control_type_from_string_prefix(button_config);
+		mapping->control.type = type;
+		switch (type) {
+		case CONTROL_TYPE_BUTTON:
+			sscanf(button_config, "button;%"SCNu8,
+					&mapping->control.button.index);
+			break;
+
+		case CONTROL_TYPE_AXIS:
+			sscanf(button_config, "axis;%"SCNu8";%"SCNi16,
+					&mapping->control.axis.index,
+					&mapping->control.axis.value);
+			break;
+
+		case CONTROL_TYPE_HAT:
+			sscanf(button_config, "hat;%"SCNu8";%"SCNi8"\n",
+					&mapping->control.hat.index,
+					&mapping->control.hat.value);
+			break;
+
+		default:
+			printf("Type %s not handled yet.\n",
+					control_type_to_str(type));
+			break;
+		}
+	}
+
+	return 0;
+}
+
+char *canonicalize_joystick_name(char *name)
+{
+	size_t len;
+
+	len = strlen(name);
+	while (len--)
+		if (!isalnum(name[len]))
+			name[len] = '_';
+		else
+			name[len] = tolower(name[len]);
+
+	return name;
+}
+
+const char *control_type_to_str(enum control_type type)
+{
+	switch (type) {
+	case CONTROL_TYPE_BUTTON:
+		return "button";
+
+	case CONTROL_TYPE_AXIS:
+		return "axis";
+
+	case CONTROL_TYPE_BALL:
+		return "ball";
+
+	case CONTROL_TYPE_HAT:
+		return "hat";
+
+	default:
+		return "(invalid)";
+	}
+}
+
+const char *gb_button_to_str(enum gb_button button)
+{
+	switch (button) {
+	case GB_BUTTON_UP:
+		return "up";
+
+	case GB_BUTTON_RIGHT:
+		return "right";
+
+	case GB_BUTTON_DOWN:
+		return "down";
+
+	case GB_BUTTON_LEFT:
+		return "left";
+
+	case GB_BUTTON_A:
+		return "A";
+
+	case GB_BUTTON_B:
+		return "B";
+
+	case GB_BUTTON_START:
+		return "start";
+
+	case GB_BUTTON_SELECT:
+		return "select";
+
+	default:
+		return "(unknown)";
+	}
+}
+
+

--- a/src/joystick_config.c
+++ b/src/joystick_config.c
@@ -39,6 +39,10 @@ void close_joystick_config(struct joystick_config *jc)
 		return;
 
 	SDL_JoystickClose(jc->joystick.joystick);
+	if (jc->joystick.name == NULL)
+		return;
+
+	free(jc->joystick.name);
 }
 
 void cleanup_joystick_config(struct joystick_config *joystick_config)
@@ -70,7 +74,9 @@ int init_joystick_config(struct joystick_config *joystick_config,
 		fprintf(stderr, "SDL_JoystickOpen(%d)\n", index);
 		return -EINVAL;
 	}
-	joystick->name = SDL_JoystickNameForIndex(index);
+	joystick->name = strdup(SDL_JoystickNameForIndex(index));
+	if (joystick->name == NULL)
+		return -errno;
 	joystick->num.axes = SDL_JoystickNumAxes(joystick->joystick);
 	joystick->num.balls = SDL_JoystickNumBalls(joystick->joystick);
 	joystick->num.hats = SDL_JoystickNumHats(joystick->joystick);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+
+#include "utils.h"
+
+void cleanup_string(char **str)
+{
+	if (str == NULL || *str == NULL)
+		return;
+
+	free(*str);
+	*str = NULL;
+}
+
+void cleanup_file(FILE **pfile)
+{
+	if (pfile == NULL || *pfile == NULL)
+		return;
+
+	fclose(*pfile);
+	*pfile = NULL;
+}

--- a/tools/joypad_mapping/joypad_mapping.c
+++ b/tools/joypad_mapping/joypad_mapping.c
@@ -394,7 +394,8 @@ static bool handle_event(struct joystick_config *joystick_config,
 		mapping.button = *button;
 		mapping.control.type = CONTROL_TYPE_AXIS;
 		mapping.control.axis.index = event->jaxis.axis;
-		mapping.control.axis.value = event->jaxis.value;
+		mapping.control.axis.value =
+				event->jaxis.value > 0 ? INT16_MAX : INT16_MIN;
 		if (!check_mapping_is_available(mappings, &mapping)) {
 			printf("Axis %"PRIu8"%s already assigned.\n",
 					event->jaxis.axis,

--- a/tools/joypad_mapping/joypad_mapping.c
+++ b/tools/joypad_mapping/joypad_mapping.c
@@ -1,0 +1,391 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <error.h>
+#include <stdbool.h>
+
+#include <SDL/SDL.h>
+
+#define MAX_JOYSTICKS 10
+#define INPUT_LENGTH 4
+#define MAPPINGS_SIZE 8
+
+struct joystick {
+	SDL_Joystick *joystick;
+	const char *name;
+	int index;
+	struct {
+		int axes;
+		int balls;
+		int hats;
+		int buttons;
+	} num;
+};
+
+enum control_type {
+	CONTROL_TYPE_AXIS,
+	CONTROL_TYPE_BALL,
+	CONTROL_TYPE_HAT,
+	CONTROL_TYPE_BUTTON,
+};
+
+enum gb_button {
+	GB_BUTTON_FIRST,
+
+	GB_BUTTON_UP = GB_BUTTON_FIRST,
+	GB_BUTTON_RIGHT,
+	GB_BUTTON_DOWN,
+	GB_BUTTON_LEFT,
+	GB_BUTTON_A,
+	GB_BUTTON_B,
+	GB_BUTTON_START,
+	GB_BUTTON_SELECT,
+
+	GB_BUTTON_LAST = GB_BUTTON_SELECT,
+	GB_BUTTON_INVALID
+};
+
+struct control {
+	enum control_type type;
+	union {
+		struct {
+			uint8_t index;
+			int16_t value;
+		} axis;
+		struct {
+			uint8_t index;
+			uint8_t value;
+		} hat;
+		struct {
+			uint8_t index;
+		} button;
+	};
+};
+
+struct mapping {
+	enum gb_button button;
+	struct control control;
+};
+
+static void close_joystick(struct joystick *joystick)
+{
+	if (joystick == NULL || joystick->joystick == NULL)
+		return;
+
+	SDL_JoystickClose(joystick->joystick);
+}
+
+static const char *gb_button_to_str(enum gb_button button)
+{
+	switch (button) {
+	case GB_BUTTON_UP:
+		return "up";
+
+	case GB_BUTTON_RIGHT:
+		return "right";
+
+	case GB_BUTTON_DOWN:
+		return "down";
+
+	case GB_BUTTON_LEFT:
+		return "left";
+
+	case GB_BUTTON_A:
+		return "A";
+
+	case GB_BUTTON_B:
+		return "B";
+
+	case GB_BUTTON_START:
+		return "start";
+
+	case GB_BUTTON_SELECT:
+		return "select";
+
+	default:
+		return "(unknown)";
+	}
+}
+
+static void next_button(enum gb_button *button)
+{
+	if (*button == GB_BUTTON_INVALID)
+		*button = GB_BUTTON_FIRST;
+	else
+		(*button)++;
+
+	if (*button != GB_BUTTON_INVALID)
+		printf("Configuring button %s\n", gb_button_to_str(*button));
+}
+
+static bool handle_event(SDL_Event *event, struct mapping *mapping,
+		enum gb_button *button, int joystick)
+{
+	if (SDL_PollEvent(event) == 0)
+		return true;
+
+	switch (event->type) {
+	case SDL_JOYBUTTONDOWN:
+		if (event->jbutton.which != joystick)
+			return true;
+
+		printf("%s mapped to button %"PRIu8"\n",
+				gb_button_to_str(*button),
+				event->jbutton.button);
+		mapping->button = *button;
+		mapping->control.type = CONTROL_TYPE_BUTTON;
+		mapping->control.button.index = event->jbutton.button;
+		next_button(button);
+		break;
+
+	case SDL_JOYBUTTONUP:
+		return true;
+
+	case SDL_JOYAXISMOTION:
+		if (event->jaxis.which != joystick || event->jaxis.value == 0)
+			return true;
+
+		printf("%s mapped to axis %"PRIu8", value %"PRIi16"\n",
+				gb_button_to_str(*button), event->jaxis.axis,
+				event->jaxis.value);
+		mapping->button = *button;
+		mapping->control.type = CONTROL_TYPE_AXIS;
+		mapping->control.axis.index = event->jaxis.axis;
+		mapping->control.axis.value = event->jaxis.value;
+		next_button(button);
+		break;
+
+	case SDL_JOYHATMOTION:
+		if (event->jhat.which != joystick ||
+				event->jhat.value == SDL_HAT_CENTERED)
+			return true;
+
+		printf("%s mapped to hat %"PRIu8", value %"PRIi16"\n",
+				gb_button_to_str(*button), event->jhat.hat,
+				event->jhat.value);
+		mapping->button = *button;
+		mapping->control.type = CONTROL_TYPE_HAT;
+		mapping->control.hat.index = event->jhat.hat;
+		mapping->control.hat.value = event->jhat.value;
+		next_button(button);
+		break;
+
+	case SDL_QUIT:
+		printf("Quitting on user's request.\n");
+		return false;
+
+	default:
+		printf("Unhandled event %"PRIu8"\n", event->type);
+	}
+
+	return *button != GB_BUTTON_INVALID;
+}
+
+static void cleanup_file(FILE **pfile)
+{
+	if (pfile == NULL || *pfile == NULL)
+		return;
+
+	fclose(*pfile);
+	*pfile = NULL;
+}
+
+static void cleanup_string(char **str)
+{
+	if (str == NULL || *str == NULL)
+		return;
+
+	free(*str);
+	*str = NULL;
+}
+
+static const char *control_type_to_str(enum control_type type)
+{
+	switch (type) {
+	case CONTROL_TYPE_BUTTON:
+		return "button";
+
+	case CONTROL_TYPE_AXIS:
+		return "axis";
+
+	case CONTROL_TYPE_BALL:
+		return "ball";
+
+	case CONTROL_TYPE_HAT:
+		return "hat";
+
+	default:
+		return "(invalid)";
+	}
+}
+
+static char *canonicalize_joystick_name(char *name)
+{
+	size_t len;
+
+	len = strlen(name);
+	while (len--)
+		if (!isalnum(name[len]))
+			name[len] = '_';
+		else
+			name[len] = tolower(name[len]);
+
+	return name;
+}
+
+static int write_mapping(struct mapping mappings[MAPPINGS_SIZE],
+		const char *mappings_dir, const char *name)
+{
+	int ret;
+	enum gb_button button;
+	char __attribute__((cleanup(cleanup_string)))*path = NULL;
+	char __attribute__((cleanup(cleanup_string)))*canon_name = NULL;
+	FILE __attribute__((cleanup(cleanup_file)))*mapping_file = NULL;
+	struct mapping *mapping;
+	const char *type_name;
+
+	canon_name = strdup(name);
+	if (canon_name == NULL) {
+		perror("strdup");
+		return EXIT_FAILURE;
+	}
+	canonicalize_joystick_name(canon_name);
+	ret = asprintf(&path, "%s/%s.mapping", mappings_dir, canon_name);
+	if (ret < 0) {
+		fprintf(stderr, "asprintf failed\n");
+		return EXIT_FAILURE;
+	}
+
+	mapping_file = fopen(path, "wbe");
+	if (mapping_file == NULL) {
+		perror("fopen");
+		return EXIT_FAILURE;
+	}
+
+	fprintf(mapping_file, "name=%s\n", name);
+	for (button = GB_BUTTON_FIRST; button <= GB_BUTTON_LAST; button++) {
+		mapping = mappings + button;
+		type_name = control_type_to_str(mapping->control.type);
+		fprintf(mapping_file, "%s=%s;", gb_button_to_str(button),
+				type_name);
+		switch (mapping->control.type) {
+		case CONTROL_TYPE_BUTTON:
+			fprintf(mapping_file, "%"PRIu8"\n",
+					mapping->control.button.index);
+			break;
+
+		case CONTROL_TYPE_AXIS:
+			fprintf(mapping_file, "%"PRIu8";%"PRIi16"\n",
+					mapping->control.axis.index,
+					mapping->control.axis.value);
+			break;
+
+		case CONTROL_TYPE_HAT:
+			fprintf(mapping_file, "%"PRIu8";%"PRIi16"\n",
+					mapping->control.hat.index,
+					mapping->control.hat.value);
+			break;
+
+		default:
+			fprintf(stderr, "Unhandled control type %s\n",
+					type_name);
+		}
+	}
+
+	return EXIT_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+	int i;
+	int ret;
+	int num_joysticks;
+	char input[INPUT_LENGTH];
+	long value;
+	char *endptr;
+	struct joystick __attribute__((cleanup(close_joystick))) joystick = {
+			.joystick = NULL
+	};
+	SDL_Event event;
+	enum gb_button button;
+	struct mapping mappings[MAPPINGS_SIZE];
+	const char *progname;
+	const char *mappings_dir;
+
+	progname = basename(argv[0]);
+	if (argc != 2)
+		error(EXIT_FAILURE, 0, "usage: %s mappings_dir", progname);
+	mappings_dir = argv[1];
+
+	printf("%s[%jd] starting\n", progname, (intmax_t)getpid());
+	ret = SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0;
+	if (ret < 0)
+		error(EXIT_FAILURE, 0, "SDL_Init(SDL_INIT_JOYSTICK)");
+	atexit(SDL_Quit);
+	SDL_JoystickEventState(SDL_ENABLE);
+
+	num_joysticks = SDL_NumJoysticks();
+	if (num_joysticks == 0)
+		error(EXIT_FAILURE, 0, "No joystick detected, aborting");
+
+	printf("%d joysticks detected\n", num_joysticks);
+
+	for (i = 0; i < num_joysticks; i++)
+		printf("Joystick %d's name is \"%s\"\n", i,
+				SDL_JoystickName(i));
+
+	if (num_joysticks == 1) {
+		joystick.index = 0;
+	} else {
+		printf("choose which one you want to configure [0 - %d]:\n > ",
+				num_joysticks - 1);
+		if (fgets(input, INPUT_LENGTH, stdin) == NULL)
+			error(EXIT_FAILURE, 0, "Short input, aborting");
+
+		/* right strip white spaces (especially, newlines) */
+		i = strlen(input) - 1;
+		while (isspace(input[i]))
+			input[i--] = '\0';
+
+		value = strtol(input, &endptr, 10);
+		if (*endptr != '\0')
+			error(EXIT_FAILURE, 0, "Invalid input \"%s\", aborting",
+					input);
+		if (value < 0 || value >= num_joysticks)
+			error(EXIT_FAILURE, 0,
+					"Index %ld out of range, aborting",
+					value);
+		joystick.index = value;
+	}
+
+	joystick.joystick = SDL_JoystickOpen(joystick.index);
+	if (joystick.joystick == NULL)
+		error(EXIT_FAILURE, 0, "SDL_JoystickOpen(%d)", joystick.index);
+	joystick.name = SDL_JoystickName(joystick.index);
+	joystick.num.axes = SDL_JoystickNumAxes(joystick.joystick);
+	joystick.num.balls = SDL_JoystickNumBalls(joystick.joystick);
+	joystick.num.hats = SDL_JoystickNumHats(joystick.joystick);
+	joystick.num.buttons = SDL_JoystickNumButtons(joystick.joystick);
+
+	printf("Configuring joystick %d: %s\n", joystick.index, joystick.name);
+	printf("\tAxes: %d\n", joystick.num.axes);
+	printf("\tBalls: %d\n", joystick.num.balls);
+	printf("\tHats: %d\n", joystick.num.hats);
+	printf("\tButtons: %d\n", joystick.num.buttons);
+
+	button = GB_BUTTON_INVALID;
+	next_button(&button);
+	while (handle_event(&event, mappings + button, &button, joystick.index))
+		;
+
+	/* quit if mapping hasn't completed */
+	if (button != GB_BUTTON_INVALID)
+		return EXIT_SUCCESS;
+
+	/* otherwise, write to file */
+	return write_mapping(mappings, mappings_dir, joystick.name);
+}

--- a/tools/joypad_mapping/joypad_mapping.c
+++ b/tools/joypad_mapping/joypad_mapping.c
@@ -134,8 +134,6 @@ static const char *event_type_to_string(uint32_t type)
 	}
 }
 
-#define have_same_sign(n1, n2) (((n1) * (n2)) >= 0)
-
 static bool controls_are_equal(const struct control *c1,
 		const struct control *c2)
 {


### PR DESCRIPTION
Adds support of gamepads.
A configuration / test tool is provided, **joypad\_mapping**. It allows to generate a mapping configuration, which will map joysticks controls to the game boy buttons.
Generated files must be placed in **~/.emgb/** in order to be detected by the emulator.
Joystick for which a configuration exist will be used automatically upon detection and disconnection / reconnection will be handled gracefully.

Buttons and axis are supported, hats may work too, but I have no controller with hats available to confirm.