### PR TITLE
Dev debug blarg 04 branch

### DIFF
--- a/include/console_debugger.h
+++ b/include/console_debugger.h
@@ -37,6 +37,7 @@ struct console_debugger {
 	char path[EMGB_CONSOLE_DEBUGGER_PATH_MAX];
 	bool active;
 	bool next;
+	bool hud;
 	struct editline *editline;
 	struct history *history;
 	struct HistEvent histevent;

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -19,11 +19,11 @@ struct s_register
 				union {
 					uint8_t f;
 					struct {
-						uint8_t zero:4;
-						bool cf:1;
-						bool hf:1;
-						bool nf:1;
-						bool zf:1;
+						uint8_t zero:4; /* bits 0->3 */
+						bool cf:1; /* bit 4 */
+						bool hf:1; /* bit 5 */
+						bool nf:1; /* bit 6 */
+						bool zf:1; /* bit 7 */
 					};
 				};
 				uint8_t a;

--- a/resources/table_gb.html
+++ b/resources/table_gb.html
@@ -284,7 +284,7 @@
 <td axis="-1++|1|4|Subtracts one from b.">dec b</td>
 <td axis="----|2|8|Loads * into b.">ld b,*</td>
 <td axis="+000|1|4|The contents of a are rotated left one bit position. The contents of bit 7 are copied to the carry flag and bit 0.">rlca</td>
-<td axis="----|3|20|Loads ** into sp.">ld (**),sp</td>
+<td axis="----|3|20|Put Stack Pointer (SP) at address **.">ld (**),sp</td>
 <td axis="+0+-|1|8|The value of bc is added to hl.">add hl,bc</td>
 <td axis="----|1|8|Loads the value pointed to by bc into a.">ld a,(bc)</td>
 <td axis="----|1|8|Subtracts one from bc.">dec bc</td>
@@ -552,7 +552,7 @@
 <td axis="----|1|16|sp is decremented and h is stored into the memory location pointed to by sp. sp is decremented again and l is stored into the memory location pointed to by sp.">push hl</td>
 <td axis="001+|2|8|Bitwise AND on a with *.">and *</td>
 <td axis="----|1|32|The current pc value plus one is pushed onto the stack, then is loaded with 20h.">rst 20h</td>
-<td axis="+0+0|2|16|If condition cc is true, the top stack entry is popped into pc.">add sp,*</td>
+<td axis="+0+0|2|16|Add * to Stack Pointer (SP).">add sp,*</td>
 <td axis="----|1|4|Loads the value of hl into pc.">jp (hl)</td>
 <td axis="----|3|16|Put a into memory location **.">ld (**),a</td>
 <td axis="----|1|4|Undefined.">und</td>

--- a/resources/table_gb.html
+++ b/resources/table_gb.html
@@ -500,7 +500,7 @@
 <td axis="+1++|1|4|Subtracts h from a and affects flags according to the result. a is not modified.">cp h</td>
 <td axis="+1++|1|4|Subtracts l from a and affects flags according to the result. a is not modified.">cp l</td>
 <td axis="+1++|1|8|Subtracts (hl) from a and affects flags according to the result. a is not modified.">cp (hl)</td>
-<td axis="+1++|1|4|Subtracts a from a and affects flags according to the result. a is not modified.">cp a</td>
+<td axis="0101|1|4|Subtracts a from a and affects flags according to the result. a is not modified.">cp a</td>
 </tr>
 <tr>
 <th>C</th>

--- a/resources/table_gb.html
+++ b/resources/table_gb.html
@@ -348,7 +348,7 @@
 <td axis="-0++|1|4|Adds one to a.">inc a</td>
 <td axis="-1++|1|4|Subtracts one from a.">dec a</td>
 <td axis="----|2|8|Loads * into a.">ld a,*</td>
-<td axis="*0*-|1|4|Inverts the carry flag.">ccf</td>
+<td axis="*00-|1|4|Inverts the carry flag.">ccf</td>
 </tr>
 <tr>
 <th>4</th>

--- a/resources/table_gb.html
+++ b/resources/table_gb.html
@@ -283,7 +283,7 @@
 <td axis="-0++|1|4|Adds one to b.">inc b</td>
 <td axis="-1++|1|4|Subtracts one from b.">dec b</td>
 <td axis="----|2|8|Loads * into b.">ld b,*</td>
-<td axis="+00-|1|4|The contents of a are rotated left one bit position. The contents of bit 7 are copied to the carry flag and bit 0.">rlca</td>
+<td axis="+000|1|4|The contents of a are rotated left one bit position. The contents of bit 7 are copied to the carry flag and bit 0.">rlca</td>
 <td axis="----|3|20|Loads ** into sp.">ld (**),sp</td>
 <td axis="+0+-|1|8|The value of bc is added to hl.">add hl,bc</td>
 <td axis="----|1|8|Loads the value pointed to by bc into a.">ld a,(bc)</td>

--- a/resources/table_gb.html
+++ b/resources/table_gb.html
@@ -291,7 +291,7 @@
 <td axis="-0++|1|4|Adds one to c.">inc c</td>
 <td axis="-1++|1|4|Subtracts one from c.">dec c</td>
 <td axis="----|2|8|Loads * into c.">ld c,*</td>
-<td axis="+00-|1|4|The contents of a are rotated right one bit position. The contents of bit 0 are copied to the carry flag and bit 7.">rrca</td>
+<td axis="+000|1|4|The contents of a are rotated right one bit position. The contents of bit 0 are copied to the carry flag and bit 7.">rrca</td>
 </tr>
 <tr>
 <th>1</th>
@@ -302,7 +302,7 @@
 <td axis="-0++|1|4|Adds one to d.">inc d</td>
 <td axis="-1++|1|4|Subtracts one from d.">dec d</td>
 <td axis="----|2|8|Loads * into d.">ld d,*</td>
-<td axis="+00-|1|4|The contents of a are rotated left one bit position. The contents of bit 7 are copied to the carry flag and the previous contents of the carry flag are copied to bit 0.">rla</td>
+<td axis="+000|1|4|The contents of a are rotated left one bit position. The contents of bit 7 are copied to the carry flag and the previous contents of the carry flag are copied to bit 0.">rla</td>
 <td axis="----|2|8|The signed value * is added to pc. The jump is measured from the start of the instruction opcode.">jr *</td>
 <td axis="+0+-|1|8|The value of de is added to hl.">add hl,de</td>
 <td axis="----|1|8|Loads the value pointed to by de into a.">ld a,(de)</td>
@@ -310,7 +310,7 @@
 <td axis="-0++|1|4|Adds one to e.">inc e</td>
 <td axis="-1++|1|4|Subtracts one from e.">dec e</td>
 <td axis="----|2|8|Loads * into e.">ld e,*</td>
-<td axis="+00-|1|4|The contents of a are rotated right one bit position. The contents of bit 0 are copied to the carry flag and the previous contents of the carry flag are copied to bit 7.">rra</td>
+<td axis="+000|1|4|The contents of a are rotated right one bit position. The contents of bit 0 are copied to the carry flag and the previous contents of the carry flag are copied to bit 7.">rra</td>
 </tr>
 <tr>
 <th>2</th>

--- a/resources/table_gb.html
+++ b/resources/table_gb.html
@@ -571,7 +571,7 @@
 <td axis="----|1|16|sp is decremented and a is stored into the memory location pointed to by sp. sp is decremented again and f is stored into the memory location pointed to by sp.">push af</td>
 <td axis="000+|2|8|Bitwise OR on a with *.">or *</td>
 <td axis="----|1|32|The current pc value plus one is pushed onto the stack, then is loaded with 30h.">rst 30h</td>
-<td axis="----|2|12|Put SP + * effective address into HL.">ldhl sp,*</td>
+<td axis="-0-0|2|12|Put SP + * effective address into HL.">ldhl sp,*</td>
 <td axis="----|1|8|Loads the value of hl into sp.">ld sp,hl</td>
 <td axis="----|3|16|Put value at address ** into a.">ld a,(**)</td>
 <td axis="----|1|4|Enable interrupts. This instruction enables interrupts but not immediately. Interrupts are enabled after instruction after EI is executed.">ei</td>

--- a/resources/table_gb.html
+++ b/resources/table_gb.html
@@ -571,7 +571,7 @@
 <td axis="----|1|16|sp is decremented and a is stored into the memory location pointed to by sp. sp is decremented again and f is stored into the memory location pointed to by sp.">push af</td>
 <td axis="000+|2|8|Bitwise OR on a with *.">or *</td>
 <td axis="----|1|32|The current pc value plus one is pushed onto the stack, then is loaded with 30h.">rst 30h</td>
-<td axis="----|1|12|Put SP + * effective address into HL.">ldhl sp,*</td>
+<td axis="----|2|12|Put SP + * effective address into HL.">ldhl sp,*</td>
 <td axis="----|1|8|Loads the value of hl into sp.">ld sp,hl</td>
 <td axis="----|3|16|Put value at address ** into a.">ld a,(**)</td>
 <td axis="----|1|4|Enable interrupts. This instruction enables interrupts but not immediately. Interrupts are enabled after instruction after EI is executed.">ei</td>

--- a/src/console_debugger.c
+++ b/src/console_debugger.c
@@ -1065,7 +1065,7 @@ static void display_stack(struct console_debugger *debugger)
 {
 	int line;
 	unsigned lines;
-	unsigned mem;
+	int mem;
 	uint16_t sp;
 	int x;
 
@@ -1078,7 +1078,8 @@ static void display_stack(struct console_debugger *debugger)
 	if (mem > 0xffff)
 		mem = 0xffff;
 	for (line = debugger->terminal.rows / 4;
-			line < debugger->terminal.rows / 2 + 1; mem -= 2, line++) {
+			line < debugger->terminal.rows / 2 + 1 &&
+			mem >= 0; mem -= 2, line++) {
 		cursor_move_to(x, line);
 		printf_bold(mem / 2 == sp / 2, "%.04"PRIx16":%.04"PRIx16, mem,
 				read16bit(mem, debugger->gb));

--- a/src/console_debugger.c
+++ b/src/console_debugger.c
@@ -398,6 +398,65 @@ static void console_debugger_memory(struct console_debugger *debugger)
 	}
 }
 
+static void cursor_save_pos(void)
+{
+	printf("\033[s");
+}
+
+static void cursor_restore_pos(void)
+{
+	printf("\033[u");
+}
+
+static void cursor_move_to(int x, int y)
+{
+	printf("\033[%d;%df", y, x);
+}
+
+static void bold_color(void)
+{
+	printf("\e[1m");
+}
+
+static void inverted_color(void)
+{
+	printf("\e[7m");
+}
+
+static void restore_color(void)
+{
+	printf("\e[0m");
+}
+
+static void erase_screen_lines(struct console_debugger *debugger,
+		unsigned first, unsigned last)
+{
+	unsigned i;
+
+	cursor_save_pos();
+	cursor_move_to(0, 0);
+	for (i = first; i <= last; i++)
+		printf("%*s", debugger->terminal.columns, "");
+	cursor_restore_pos();
+}
+
+static void erase_upper_screen_half(struct console_debugger *debugger)
+{
+	erase_screen_lines(debugger, 1, debugger->terminal.rows / 2 - 1);
+}
+
+static void erase_whole_screen(struct console_debugger *debugger)
+{
+	erase_screen_lines(debugger, 1, debugger->terminal.rows);
+}
+
+static void console_debugger_layout(struct console_debugger *debugger)
+{
+	debugger->hud = !debugger->hud;
+	if (debugger->hud)
+		erase_whole_screen(debugger);
+}
+
 static void console_debugger_next(struct console_debugger *debugger)
 {
 	debugger->next = true;
@@ -522,6 +581,12 @@ static struct debugger_command commands[] = {
 		.fn = console_debugger_help,
 		.name = "help",
 		.help = "Shows a little help about available commands.",
+		.argc = 1,
+	},
+	{
+		.fn = console_debugger_layout,
+		.name = "layout",
+		.help = "Toggles display of the HUD.\n",
 		.argc = 1,
 	},
 	{
@@ -661,58 +726,6 @@ static int console_debugger_get_terminal_size(struct console_debugger *debugger)
 	return 0;
 }
 
-static void cursor_save_pos(void)
-{
-	printf("\033[s");
-}
-
-static void cursor_restore_pos(void)
-{
-	printf("\033[u");
-}
-
-static void cursor_move_to(int x, int y)
-{
-	printf("\033[%d;%df", y, x);
-}
-
-static void bold_color(void)
-{
-	printf("\e[1m");
-}
-
-static void inverted_color(void)
-{
-	printf("\e[7m");
-}
-
-static void restore_color(void)
-{
-	printf("\e[0m");
-}
-
-static void erase_screen_lines(struct console_debugger *debugger,
-		unsigned first, unsigned last)
-{
-	unsigned i;
-
-	cursor_save_pos();
-	cursor_move_to(0, 0);
-	for (i = first; i <= last; i++)
-		printf("%*s", debugger->terminal.columns, "");
-	cursor_restore_pos();
-}
-
-static void erase_upper_screen_half(struct console_debugger *debugger)
-{
-	erase_screen_lines(debugger, 1, debugger->terminal.rows / 2 - 1);
-}
-
-static void erase_whole_screen(struct console_debugger *debugger)
-{
-	erase_screen_lines(debugger, 1, debugger->terminal.rows);
-}
-
 int console_debugger_init(struct console_debugger *debugger,
 		struct s_register *registers, struct s_gb *gb)
 {
@@ -753,14 +766,12 @@ int console_debugger_init(struct console_debugger *debugger,
 		ERR("tok_init");
 
 	console_debugger_get_terminal_size(debugger);
-	erase_whole_screen(debugger);
-	cursor_move_to(1, debugger->terminal.rows / 2 + 1);
 	init_registers_map(debugger);
 	/*
 	 * TODO enable debugger by default, this should be decided with a
 	 * command-line switch
 	 */
-	debugger->active = true;
+	debugger->active = false;
 
 	return 0;
 }
@@ -1092,10 +1103,12 @@ static void display_pre_prompt(struct console_debugger *debugger)
 	for (cur = instruction->real_size - 1; cur >= 1; cur--)
 		printf(" %02"PRIx8, read8bit(pc + cur, debugger->gb));
 	puts("");
-	erase_upper_screen_half(debugger);
-	display_disassembly(debugger);
-	display_registers(debugger);
-	display_stack(debugger);
+	if (debugger->hud) {
+		erase_upper_screen_half(debugger);
+		display_disassembly(debugger);
+		display_registers(debugger);
+		display_stack(debugger);
+	}
 }
 
 int console_debugger_update(struct console_debugger *debugger)

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -428,15 +428,15 @@ function generate_base_ldd_code() {
 
 function generate_base_ldhl_code() {
 	cat <<here_doc_delim
-	int8_t value = read8bit(${regs}.pc, s_gb);
-	int res;
+	int8_t value = read8bit(${regs}.pc +  1, s_gb);
+	int32_t res;
 
 	res = value + ${regs}.sp;
 
-	${regs}.cf = res & 0xffff0000;
 	${regs}.hf = ((${regs}.sp & 0x0f) + (value & 0x0f)) > 0x0f;
+	${regs}.cf = ((${regs}.sp & 0x0ff) + (value & 0x0ff)) > 0x0ff;
 
-	${regs}.hl = res & 0x0000ffff;
+	${regs}.hl = res & 0xffffu;
 here_doc_delim
 }
 

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -497,14 +497,9 @@ here_doc_delim
 
 function generate_base_rlca_code() {
 	cat <<here_doc_delim
-	bool carry;
-
-	carry = ${regs}.a & 0x80;
-	${regs}.cf = carry;
-
+	${regs}.cf = ${regs}.a & 0x80;
 	${regs}.a <<= 1;
-	${regs}.a += carry;
-	${regs}.zf = ${regs}.a == 0;
+	${regs}.a += ${regs}.cf;
 here_doc_delim
 }
 

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -537,6 +537,7 @@ here_doc_delim
 function generate_base_sbc_code() {
 	local operand=$1
 
+	echo -e "\tbool carry = ${regs}.cf;"
 	echo -e -n "\tuint8_t value = "
 	if [ "${operand}" = "(hl)" ]; then
 		echo  "read8bit(${regs}.hl, s_gb);"
@@ -547,14 +548,14 @@ function generate_base_sbc_code() {
 	fi
 
 	cat <<here_doc_delim
-	value += ${regs}.cf;
-	${regs}.cf = value > ${regs}.a;
 
-	${regs}.hf = (value & 0x0f) > (${regs}.a & 0x0f);
+	${regs}.cf = value + carry > ${regs}.a;
+	${regs}.hf = (value & 0x0f) + carry > (${regs}.a & 0x0f);
 
+	value += carry;
 	${regs}.a -= value;
 
-	${regs}.zf = ${regs}.a != 0;
+	${regs}.zf = ${regs}.a == 0;
 here_doc_delim
 }
 

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -404,7 +404,11 @@ function generate_base_ld_code() {
 		if [[ ${dst} =~ ${adress_re} ]]; then
 			dst_adress=${BASH_REMATCH[1]}
 			generate_base_ld_dst_adress_code ${dst_adress}
-			echo -e "\twrite8bit(dst_adr, src_val, s_gb);"
+			if [ ${#src} -eq 1 ]; then
+				echo -e "\twrite8bit(dst_adr, src_val, s_gb);"
+			else
+				echo -e "\twrite16bitToAddr(dst_adr, src_val, s_gb);"
+			fi
 		else
 			echo -e "\t${regs}.${dst} = src_val;"
 		fi

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -109,10 +109,12 @@ here_doc_delim
 	echo -e "\tresult = ${regs}.${dst} + value;"
 	if [ "${add_carry}" = "true" ]; then
 		echo -e "\tresult += ${regs}.cf;"
+		echo -e "\t${regs}.hf = ((${regs}.${dst} & 0x0f) + (value & 0x0f) + ${regs}.cf) > 0x0f;"
+	else
+		echo -e "\t${regs}.hf = ((${regs}.${dst} & 0x0f) + (value & 0x0f)) > 0x0f;"
 	fi
 	cat <<here_doc_delim
 	${regs}.cf = result & ${carry_mask};
-	${regs}.hf = ((${regs}.${dst} & 0x0f) + (value & 0x0f)) > 0x0f;
 
 	${regs}.${dst} = 0xffffu & result;
 here_doc_delim

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -48,9 +48,7 @@ function generate_base_sub_gen_code() {
 	local target
 
 	if [ "${operand}" = "a" ]; then
-		cat <<here_doc_delim
-	${regs}.a = 0;
-here_doc_delim
+		# flag values are hardcoded in table_gb.html
 		return 0
 	fi
 

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -95,23 +95,27 @@ here_doc_delim
 	echo -n -e "\tvalue = "
 	if [ "${src}" = "*" ]; then
 		carry_mask="0xff00u"
+		half_carry_mask="0x0fu"
 		echo "read8bit(${pc} + 1, s_gb);"
 	elif [ "${src}" = "**" ]; then
 		carry_mask="0xffff0000u"
+		half_carry_mask="0x0fffu"
 		echo "read16bit(${pc} + 1, s_gb);"
 	elif [ "${src}" = "(hl)" ]; then
 		carry_mask="0xff00u"
+		half_carry_mask="0x0fu"
 		echo "read16bit(${regs}.hl, s_gb);"
 	else
 		carry_mask="0xffff0000u"
+		half_carry_mask="0x0fffu"
 		echo "${regs}.${src};"
 	fi
 	echo -e "\tresult = ${regs}.${dst} + value;"
 	if [ "${add_carry}" = "true" ]; then
 		echo -e "\tresult += ${regs}.cf;"
-		echo -e "\t${regs}.hf = ((${regs}.${dst} & 0x0f) + (value & 0x0f) + ${regs}.cf) > 0x0f;"
+		echo -e "\t${regs}.hf = ((${regs}.${dst} & ${half_carry_mask}) + (value & ${half_carry_mask}) + ${regs}.cf) > ${half_carry_mask};"
 	else
-		echo -e "\t${regs}.hf = ((${regs}.${dst} & 0x0f) + (value & 0x0f)) > 0x0f;"
+		echo -e "\t${regs}.hf = ((${regs}.${dst} & ${half_carry_mask}) + (value & ${half_carry_mask})) > ${half_carry_mask};"
 	fi
 	cat <<here_doc_delim
 	${regs}.cf = result & ${carry_mask};

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -88,12 +88,7 @@ function generate_base_add_carry_code() {
 	local src=${operands[1]}
 	local add_carry=$2
 
-	cat <<here_doc_delim
-	uint16_t value;
-	uint32_t result;
-
-here_doc_delim
-	echo -n -e "\tvalue = "
+	value_type="uint16_t"
 	if [ ${#dst} -eq 2 ]; then
 		carry_mask="0x0000ffffu"
 		half_carry_mask="0x0fffu"
@@ -105,7 +100,14 @@ here_doc_delim
 	if [ "$3" = "0xE8" ]; then
 		carry_mask="0x00ffu"
 		half_carry_mask="0x0fu"
+		value_type="int8_t"
 	fi
+	cat <<here_doc_delim
+	${value_type} value;
+	uint32_t result;
+
+here_doc_delim
+	echo -n -e "\tvalue = "
 	if [ "${src}" = "*" ]; then
 		echo "read8bit(${pc} + 1, s_gb);"
 	elif [ "${src}" = "**" ]; then

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -103,9 +103,13 @@ here_doc_delim
 		carry_mask="0xff00u"
 		half_carry_mask="0x0fu"
 		echo "read16bit(${regs}.hl, s_gb);"
-	else
+	elif [ ${#dst} -eq 2 ]; then
 		carry_mask="0xffff0000u"
 		half_carry_mask="0x0fffu"
+		echo "${regs}.${src};"
+	else
+		carry_mask="0xff00u"
+		half_carry_mask="0x0fu"
 		echo "${regs}.${src};"
 	fi
 	echo -e "\tresult = ${regs}.${dst} + value;"

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -487,11 +487,10 @@ function generate_base_rla_code() {
 	cat <<here_doc_delim
 	bool carry;
 
-	carry = ${regs}.a & 0x80;
-	${regs}.cf = carry;
-
+	carry = ${regs}.cf;
+	${regs}.cf = ${regs}.a & 0x80;
 	${regs}.a <<= 1;
-	${regs}.zf = ${regs}.a == 0;
+	${regs}.a += carry;
 here_doc_delim
 }
 
@@ -511,20 +510,14 @@ function generate_base_rra_code() {
 	${regs}.cf = ${regs}.a & 0x01;
 	${regs}.a >>= 1;
 	${regs}.a += carry << 7;
-
-	${regs}.zf = ${regs}.a == 0;
 here_doc_delim
 }
 
 function generate_base_rrca_code() {
 	cat <<here_doc_delim
-	bool carry = ${regs}.a & 0x01;
-
-	${regs}.cf = carry;
+	${regs}.cf = ${regs}.a & 0x01;
 	${regs}.a >>= 1;
-
-	${regs}.a |= carry << 7;
-	${regs}.zf = ${regs}.a == 0;
+	${regs}.a += (${regs}.cf << 7);
 here_doc_delim
 }
 

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -94,12 +94,16 @@ function generate_base_add_carry_code() {
 here_doc_delim
 	echo -n -e "\tvalue = "
 	if [ "${src}" = "*" ]; then
+		carry_mask="0xff00u"
 		echo "read8bit(${pc} + 1, s_gb);"
 	elif [ "${src}" = "**" ]; then
+		carry_mask="0xffff0000u"
 		echo "read16bit(${pc} + 1, s_gb);"
 	elif [ "${src}" = "(hl)" ]; then
+		carry_mask="0xff00u"
 		echo "read16bit(${regs}.hl, s_gb);"
 	else
+		carry_mask="0xffff0000u"
 		echo "${regs}.${src};"
 	fi
 	echo -e "\tresult = ${regs}.${dst} + value;"
@@ -107,7 +111,7 @@ here_doc_delim
 		echo -e "\tresult += ${regs}.cf;"
 	fi
 	cat <<here_doc_delim
-	${regs}.cf = result & 0xffff0000;
+	${regs}.cf = result & ${carry_mask};
 	${regs}.hf = ((${regs}.${dst} & 0x0f) + (value & 0x0f)) > 0x0f;
 
 	${regs}.${dst} = 0xffffu & result;

--- a/tools/base_gen.sh
+++ b/tools/base_gen.sh
@@ -49,6 +49,9 @@ function generate_base_sub_gen_code() {
 
 	if [ "${operand}" = "a" ]; then
 		# flag values are hardcoded in table_gb.html
+		if [ "${apply}" = "true" ]; then
+			echo -e "\t${regs}.a = 0;"
+		fi
 		return 0
 	fi
 

--- a/tools/cb_gen.sh
+++ b/tools/cb_gen.sh
@@ -46,7 +46,7 @@ function generate_cb_rl_code() {
 
 	carry = ${regs}.cf;
 	value = ${value};
-	${regs}.cf = !BIT(7, value);
+	${regs}.cf = BIT(7, value);
 	value <<= 1;
 	value += carry;
 	${regs}.zf = value == 0;

--- a/tools/joypad_mapping/joypad_mapping.c
+++ b/tools/joypad_mapping/joypad_mapping.c
@@ -111,12 +111,14 @@ static const char *event_type_to_string(uint32_t type)
 		return "SDL_CLIPBOARDUPDATE";
 	case SDL_DROPFILE:
 		return "SDL_DROPFILE";
+		/* not present for every SDL2 version
 	case SDL_DROPTEXT:
 		return "SDL_DROPTEXT";
 	case SDL_DROPBEGIN:
 		return "SDL_DROPBEGIN";
 	case SDL_DROPCOMPLETE:
 		return "SDL_DROPCOMPLETE";
+		*/
 	case SDL_AUDIODEVICEADDED:
 		return "SDL_AUDIODEVICEADDED";
 	case SDL_AUDIODEVICEREMOVED:

--- a/tools/joypad_mapping/joypad_mapping.c
+++ b/tools/joypad_mapping/joypad_mapping.c
@@ -361,7 +361,7 @@ const char cnorm[] = { 0x1b, 0x5b, 0x3f, 0x31, 0x32, 0x6c, 0x1b, 0x5b, 0x3f,
 
 static void restore_cursor(void)
 {
-	printf(cnorm);
+	printf("%s", cnorm);
 }
 
 static bool handle_test_event(const char *mappings_dir,
@@ -494,7 +494,7 @@ static int test_joypad(const char *mappings_dir)
 
 	reset_joystick_config(&joystick_config);
 
-	printf(civis);
+	printf("%s", civis);
 	atexit(restore_cursor);
 	printf("Waiting for joystick detection\n");
 	ret = SDL_Init(SDL_INIT_JOYSTICK);
@@ -599,7 +599,7 @@ int main(int argc, char **argv)
 	printf("\tHats: %d\n", joystick_config.joystick.num.hats);
 	printf("\tButtons: %d\n", joystick_config.joystick.num.buttons);
 
-	printf(civis);
+	printf("%s", civis);
 	atexit(restore_cursor);
 	button = GB_BUTTON_INVALID;
 	next_button(&button);


### PR DESCRIPTION
This patchset fixes bugs in the **0xc6** (add), **0xce** (adc) and **0xde** instructions and allows **cpu_instrs/04-op r,imm.gb** blargg test to succeed (yay!).

It also fixes a build issue whith some older (**ubuntu 16.04**) SDL2 versions, missing the definition of the **SDL_DROPXXX** constants.

A new debugger command is added too: **layout**, which allows to toggle the display of the debugger's hud. The hud is now disabled by default. This allows for example, to use the **help** command properly again.

**[Edit]** added commits to fix tests 05 and 11 too.

Now cpu_instrs tests status is: 01, 04, 05, 06, 10, 11 are **ok**, 02, 03, 07, 08 and 09 are **not**.

**[Edit2]** current status now all cpu_instrs tests are **ok**, excepted 02 and 08 which are **not**.